### PR TITLE
VF-40: Configure label for renovate-bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": ["config:base"],
   "lockFileMaintenance":{ "enabled": true },
-  "masterIssue": true
+  "masterIssue": true,
+  "labels": ["dependencies"]
 }


### PR DESCRIPTION
Renovate-bot will from now on automatically add the _dependencies_ label.