### PR TITLE
Tell renovate to allow semver ranges

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["config:base"],
+  "extends": ["config:base", ":preserveSemverRanges"],
   "lockFileMaintenance":{ "enabled": true },
   "masterIssue": true,
   "labels": ["dependencies"]


### PR DESCRIPTION
Adds `:preserveSemverRanges` to the config, which will continue to update packages, but keep the semvers static.
When we build the website we use `--frozen-lockfile`, so as long as the lockfile is updated, `package.json` is ignored.

See [renovate docs here](https://docs.renovatebot.com/config-presets/#example-configs).