### PR TITLE
[VF-64] Remove deprecated Tailwind config option

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,7 +4,6 @@ module.exports = {
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
-  purge: ['./src/**/*.{js,jsx,ts,tsx}', './public/index.html'],
   darkMode: 'class', // or false or 'media'
   theme: {
     screens: {


### PR DESCRIPTION
Removes deprecated "purge" option in the Tailwind config. This option has been renamed to "content", which was already present. 
See https://tailwindcss.com/docs/upgrade-guide#configure-content-sources. 
