### PR TITLE
VF-73 revert logo back to img tag

### DIFF
--- a/src/components/Header/AppHeader.tsx
+++ b/src/components/Header/AppHeader.tsx
@@ -29,7 +29,8 @@ const AppHeader = (): JSX.Element => {
       <div className="hidden md:flex mx-auto p-3 space-x-8 items-center justify-center lg:px-8 w-full max-w-7xl">
         <div className="w-1/5 justify-center flex">
           <Link to="/">
-            <div className="bg-vektor-logo dark:bg-vektor-logo-dark bg-contain bg-no-repeat w-36 h-20" />
+            <img src="images/vektor-logo.svg" alt="vektorprogrammet logo" className="h-16 lg:h-20 dark:hidden" />
+            <img src="images/vektor-logo-darkmode.png" alt="vektorprogrammet logo" className="h-16 lg:h-20 hidden dark:block" />
           </Link>
         </div>
         <div className="flex flex-grow justify-between justify-self-center max-w-lg m-auto items-center w-2/5">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,11 +20,6 @@ module.exports = {
         'vektor-darkfooter': '#022346',
         'vektor-bg': '#fafdff',
       },
-      
-      backgroundImage : {
-        'vektor-logo': "url('public/images/vektor-logo.svg')",
-        'vektor-logo-dark': "url('public/images/vektor-logo-darkmode.png')",
-      },
     },
   },
   variants: {


### PR DESCRIPTION
Changed the logo back to an image tag, rather than having it as a div's background. Added another image tag only visible in darkmode, and made the original image hidden in darkmode